### PR TITLE
Updates Travis CI and packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "16"
+  - "14"
+  - "12"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "mocha": "~1.12.1"
+    "mocha": "~8.4.0"
   },
   "scripts": {
     "test": "node node_modules/mocha/bin/mocha"


### PR DESCRIPTION
Node.js versions below 10.x are not maintained anymore, so it is probably best to use some newer, still maintained versions. For release cycles of Node.js see the official site: <https://nodejs.org/en/about/releases/>.

Furthermore, the Mocha dependency has been updated to use the most recent version, fixing several vulnerabilities along the way.
Despite several major version bumps the tests still run. :)